### PR TITLE
fix issue #9: update selection when range is removed

### DIFF
--- a/demo/src/Controls.elm
+++ b/demo/src/Controls.elm
@@ -122,47 +122,47 @@ styleToString style =
 
 onButtonPressToggleStyle : Style -> Attribute EditorMsg
 onButtonPressToggleStyle style =
-    preventDefaultOn "click" (succeed ( ToggleStyle style, True ))
+    preventDefaultOn "mousedown" (succeed ( ToggleStyle style, True ))
 
 
 onButtonPressToggleList : ListType -> Attribute EditorMsg
 onButtonPressToggleList listType =
-    preventDefaultOn "click" (succeed ( WrapInList listType, True ))
+    preventDefaultOn "mousedown" (succeed ( WrapInList listType, True ))
 
 
 onButtonPressToggleBlock : String -> Attribute EditorMsg
 onButtonPressToggleBlock action =
-    preventDefaultOn "click" (succeed ( ToggleBlock action, True ))
+    preventDefaultOn "mousedown" (succeed ( ToggleBlock action, True ))
 
 
 onButtonPressWrapBlockquote : Attribute EditorMsg
 onButtonPressWrapBlockquote =
-    preventDefaultOn "click" (succeed ( WrapInBlockQuote, True ))
+    preventDefaultOn "mousedown" (succeed ( WrapInBlockQuote, True ))
 
 
 onButtonPressInsertLink : Attribute EditorMsg
 onButtonPressInsertLink =
-    preventDefaultOn "click" (succeed ( ShowInsertLinkModal, True ))
+    preventDefaultOn "mousedown" (succeed ( ShowInsertLinkModal, True ))
 
 
 onButtonPressInsertImage : Attribute EditorMsg
 onButtonPressInsertImage =
-    preventDefaultOn "click" (succeed ( ShowInsertImageModal, True ))
+    preventDefaultOn "mousedown" (succeed ( ShowInsertImageModal, True ))
 
 
 onButtonPressInsertCode : Attribute EditorMsg
 onButtonPressInsertCode =
-    preventDefaultOn "click" (succeed ( ToggleStyle Code, True ))
+    preventDefaultOn "mousedown" (succeed ( ToggleStyle Code, True ))
 
 
 onButtonPressLiftOutOfBlock : Attribute EditorMsg
 onButtonPressLiftOutOfBlock =
-    preventDefaultOn "click" (succeed ( LiftOutOfBlock, True ))
+    preventDefaultOn "mousedown" (succeed ( LiftOutOfBlock, True ))
 
 
 onButtonPressInsertHR : Attribute EditorMsg
 onButtonPressInsertHR =
-    preventDefaultOn "click" (succeed ( InsertHorizontalRule, True ))
+    preventDefaultOn "mousedown" (succeed ( InsertHorizontalRule, True ))
 
 
 createButtonForStyle : ControlState -> Style -> Icon -> Html EditorMsg
@@ -438,7 +438,7 @@ undoRedo controlState =
          else
             Disabled
         )
-        (preventDefaultOn "click" (succeed ( Undo, True )))
+        (preventDefaultOn "mousedown" (succeed ( Undo, True )))
         Solid.undo
         "undo"
     , createButton
@@ -448,7 +448,7 @@ undoRedo controlState =
          else
             Disabled
         )
-        (preventDefaultOn "click" (succeed ( Redo, True )))
+        (preventDefaultOn "mousedown" (succeed ( Redo, True )))
         Solid.redo
         "redo"
     ]

--- a/demo/src/Editor.elm
+++ b/demo/src/Editor.elm
@@ -232,6 +232,13 @@ handleShowInsertLinkModal spec model =
                 }
 
 
+{-| Dummy transform that always returns the result it receives.
+-}
+setResult : Result String State -> State -> Result String State
+setResult result _ =
+    result
+
+
 handleInsertLink : Spec -> Model -> Model
 handleInsertLink spec model =
     let
@@ -243,7 +250,7 @@ handleInsertLink spec model =
                 Nothing ->
                     model.editor
 
-                Just _ ->
+                Just state_ ->
                     let
                         attributes =
                             [ StringAttribute "href" insertLinkModal.href
@@ -260,7 +267,7 @@ handleInsertLink spec model =
                         apply
                             ( "insertLink"
                             , transform <|
-                                Commands.toggleMark markOrder linkMark Add
+                                setResult (Commands.toggleMark markOrder linkMark Add state_)
                             )
                             spec
                             model.editor
@@ -288,7 +295,7 @@ handleInsertImage spec model =
                 Nothing ->
                     model.editor
 
-                Just _ ->
+                Just state_ ->
                     let
                         params =
                             element image
@@ -303,7 +310,7 @@ handleInsertImage spec model =
                         apply
                             ( "insertImage"
                             , transform <|
-                                Commands.insertInline img
+                                setResult (Commands.insertInline img state_)
                             )
                             spec
                             model.editor

--- a/demo/src/Page/SpecExtension.elm
+++ b/demo/src/Page/SpecExtension.elm
@@ -163,7 +163,7 @@ handleInsertCaptionedImage spec model =
                 Nothing ->
                     model.editor.editor
 
-                Just _ ->
+                Just state_ ->
                     let
                         params =
                             element captionedImage
@@ -179,7 +179,7 @@ handleInsertCaptionedImage spec model =
                         apply
                             ( "insertImage"
                             , transform <|
-                                Commands.insertBlock img
+                                Editor.setResult (Commands.insertBlock img state_)
                             )
                             spec
                             model.editor.editor

--- a/js/elmEditor.js
+++ b/js/elmEditor.js
@@ -217,10 +217,6 @@ class SelectionState extends HTMLElement {
 
     selectionChange(e) {
         let selection = this.getSelectionObject(e);
-
-        if (!selection.selectionExists) {
-            return;
-        }
         let event = new CustomEvent("editorselectionchange", {detail: selection});
         this.parentNode.dispatchEvent(event);
     };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "elm-rte-toolkit",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Elm toolkit for rich text editors",
   "main": "elmEditor.js",
   "scripts": {
     "build": "babel js -d js-dist",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "publish": "./publish.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "elmEditor.js",
   "scripts": {
     "build": "babel js -d js-dist",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-npm build
+npm run build
 cd js-dist
 cp ../package.json .
 npm publish


### PR DESCRIPTION
See #9 

The webcomponent was not firing a selection change event in the case that the selection was not in the editor, which was causing the stale selection state.

Note that it also exposed some carelessness on my part in the demo for inserting links and images.  In those examples, a modal pops up that removes selection state.  I had saved the editor state for that purpose, but apparently never used it because this bug preserved the selection state 😄 .  This PR also fixes that by using the saved editor state in those cases.

Edit: It also fixes issues with losing selection state with `click` events on the toolbar.  Instead I switched it to `mousedown`, which mysteriously also seems to work on the mobile platforms I tested.  I need to look into if this is because mobile browsers support mouse events (which I thought they didn't, but idk), Elm is doing something tricky, or because I tested in an emulator/simulator and browser, the behavior is different somehow.