### PR TITLE
fix issue #10, add IME support for chrome and safari

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mweiss/elm-rte-toolkit",
     "summary": "Build rich text editors in Elm",
     "license": "BSD-3-Clause",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "exposed-modules": [
         "RichText.Annotation",
         "RichText.Commands",

--- a/js/elmEditor.js
+++ b/js/elmEditor.js
@@ -1,9 +1,5 @@
 const zeroWidthSpace = "\u200B";
 
-const isSafari = () => {
-    return window.safari !== undefined
-};
-
 const isAndroid = () => { return /(android)/i.test(navigator.userAgent); };
 
 /**
@@ -222,11 +218,6 @@ class SelectionState extends HTMLElement {
     }
 
     selectionChange(e) {
-        // In Safari, modifying the selection while composing causes text composition to end
-        // unexpectedly.  So for that browser, we do not update the selection state during composition.
-        if (isSafari() && this.parentNode.composing) {
-            return;
-        }
         let selection = this.getSelectionObject(e);
         let event = new CustomEvent("editorselectionchange", {detail: selection});
         this.parentNode.dispatchEvent(event);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-rte-toolkit",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Elm toolkit for rich text editors",
   "main": "elmEditor.js",
   "scripts": {

--- a/src/RichText/Editor.elm
+++ b/src/RichText/Editor.elm
@@ -516,7 +516,7 @@ onCompositionStart msgFunc =
 
 onCompositionEnd : (Message -> msg) -> Html.Attribute msg
 onCompositionEnd msgFunc =
-    Html.Events.on "compositionend" (D.map msgFunc (D.succeed CompositionEnd))
+    Html.Events.on "editorcompositionend" (D.map msgFunc (D.succeed CompositionEnd))
 
 
 onPasteWithData : (Message -> msg) -> Html.Attribute msg

--- a/src/RichText/Internal/BeforeInput.elm
+++ b/src/RichText/Internal/BeforeInput.elm
@@ -18,23 +18,24 @@ preventDefaultOn : CommandMap -> Spec -> Editor -> Message -> ( Message, Bool )
 preventDefaultOn commandMap spec editor msg =
     case msg of
         BeforeInputEvent inputEvent ->
-            shouldPreventDefault commandMap spec editor inputEvent
+            if inputEvent.isComposing then
+                ( msg, False )
+
+            else
+                ( msg, shouldPreventDefault commandMap spec editor inputEvent )
 
         _ ->
             ( msg, False )
 
 
-shouldPreventDefault : CommandMap -> Spec -> Editor -> InputEvent -> ( Message, Bool )
+shouldPreventDefault : CommandMap -> Spec -> Editor -> InputEvent -> Bool
 shouldPreventDefault commandMap spec editor inputEvent =
     case handleInputEvent commandMap spec editor inputEvent of
         Err _ ->
-            ( ReplaceWith editor, False )
+            False
 
-        Ok newEditor ->
-            -- HACK: Android has very strange behavior with regards to before input events, e.g.
-            -- prevent default doesn't actually stop the DOM from being modified, so
-            -- we're forcing a rerender if we update the editor state on a command
-            ( ReplaceWith <| forceRerender newEditor, True )
+        Ok _ ->
+            True
 
 
 preventDefaultOnBeforeInputDecoder : Tagger msg -> CommandMap -> Spec -> Editor -> D.Decoder ( msg, Bool )
@@ -63,12 +64,16 @@ handleInputEvent commandMap spec editor inputEvent =
 
 handleBeforeInput : InputEvent -> CommandMap -> Spec -> Editor -> Editor
 handleBeforeInput inputEvent commandMap spec editor =
-    case handleInputEvent commandMap spec editor inputEvent of
-        Err _ ->
-            editor
+    if inputEvent.isComposing then
+        editor
 
-        Ok newEditor ->
-            -- HACK: Android has very strange behavior with regards to before input events, e.g.
-            -- prevent default doesn't actually stop the DOM from being modified, so
-            -- we're forcing a rerender if we update the editor state on a command
-            forceRerender newEditor
+    else
+        case handleInputEvent commandMap spec editor inputEvent of
+            Err _ ->
+                editor
+
+            Ok newEditor ->
+                -- HACK: Android has very strange behavior with regards to before input events, e.g.
+                -- prevent default doesn't actually stop the DOM from being modified, so
+                -- we're forcing a rerender if we update the editor state on a command
+                forceRerender newEditor

--- a/src/RichText/Internal/BeforeInput.elm
+++ b/src/RichText/Internal/BeforeInput.elm
@@ -3,14 +3,7 @@ module RichText.Internal.BeforeInput exposing (..)
 import Json.Decode as D
 import RichText.Config.Command exposing (CommandMap, namedCommandListFromInputEvent)
 import RichText.Config.Spec exposing (Spec)
-import RichText.Internal.Editor
-    exposing
-        ( Editor
-        , Message(..)
-        , Tagger
-        , applyNamedCommandList
-        , forceRerender
-        )
+import RichText.Internal.Editor exposing (Editor, Message(..), Tagger, applyNamedCommandList, forceRerender, isComposing)
 import RichText.Internal.Event exposing (InputEvent)
 
 
@@ -18,7 +11,7 @@ preventDefaultOn : CommandMap -> Spec -> Editor -> Message -> ( Message, Bool )
 preventDefaultOn commandMap spec editor msg =
     case msg of
         BeforeInputEvent inputEvent ->
-            if inputEvent.isComposing then
+            if inputEvent.isComposing || isComposing editor then
                 ( msg, False )
 
             else
@@ -64,7 +57,7 @@ handleInputEvent commandMap spec editor inputEvent =
 
 handleBeforeInput : InputEvent -> CommandMap -> Spec -> Editor -> Editor
 handleBeforeInput inputEvent commandMap spec editor =
-    if inputEvent.isComposing then
+    if inputEvent.isComposing || isComposing editor then
         editor
 
     else

--- a/src/RichText/Internal/Editor.elm
+++ b/src/RichText/Internal/Editor.elm
@@ -70,7 +70,6 @@ type Message
     | CompositionEnd
     | PasteWithDataEvent PasteEvent
     | CutEvent
-    | ReplaceWith Editor
     | Init InitEvent
 
 

--- a/src/RichText/Internal/Event.elm
+++ b/src/RichText/Internal/Event.elm
@@ -19,6 +19,7 @@ type alias EditorChange =
     , selection : Maybe Selection
     , characterDataMutations : Maybe (List TextChange)
     , timestamp : Int
+    , isComposing : Bool
     }
 
 

--- a/src/RichText/Internal/KeyDown.elm
+++ b/src/RichText/Internal/KeyDown.elm
@@ -11,20 +11,24 @@ preventDefaultOn : CommandMap -> Spec -> Editor -> Message -> ( Message, Bool )
 preventDefaultOn commandMap spec editor msg =
     case msg of
         KeyDownEvent key ->
-            shouldPreventDefault commandMap spec editor key
+            if key.isComposing then
+                ( msg, False )
+
+            else
+                ( msg, shouldPreventDefault commandMap spec editor key )
 
         _ ->
             ( msg, False )
 
 
-shouldPreventDefault : CommandMap -> Spec -> Editor -> KeyboardEvent -> ( Message, Bool )
+shouldPreventDefault : CommandMap -> Spec -> Editor -> KeyboardEvent -> Bool
 shouldPreventDefault comamndMap spec editor keyboardEvent =
     case handleKeyDownEvent comamndMap spec editor keyboardEvent of
         Err _ ->
-            ( ReplaceWith editor, False )
+            False
 
-        Ok newEditor ->
-            ( ReplaceWith newEditor, True )
+        Ok _ ->
+            True
 
 
 preventDefaultOnKeyDownDecoder : Tagger msg -> CommandMap -> Spec -> Editor -> D.Decoder ( msg, Bool )
@@ -56,4 +60,8 @@ handleKeyDownEvent commandMap spec editor event =
 
 handleKeyDown : KeyboardEvent -> CommandMap -> Spec -> Editor -> Editor
 handleKeyDown keyboardEvent commandMap spec editor =
-    Result.withDefault editor <| handleKeyDownEvent commandMap spec editor keyboardEvent
+    if keyboardEvent.isComposing then
+        editor
+
+    else
+        Result.withDefault editor <| handleKeyDownEvent commandMap spec editor keyboardEvent

--- a/src/RichText/Internal/KeyDown.elm
+++ b/src/RichText/Internal/KeyDown.elm
@@ -3,7 +3,7 @@ module RichText.Internal.KeyDown exposing (..)
 import Json.Decode as D
 import RichText.Config.Command exposing (CommandMap, namedCommandListFromKeyboardEvent)
 import RichText.Config.Spec exposing (Spec)
-import RichText.Internal.Editor exposing (Editor, Message(..), Tagger, applyNamedCommandList, shortKey)
+import RichText.Internal.Editor exposing (Editor, Message(..), Tagger, applyNamedCommandList, isComposing, shortKey)
 import RichText.Internal.Event exposing (KeyboardEvent)
 
 
@@ -11,7 +11,7 @@ preventDefaultOn : CommandMap -> Spec -> Editor -> Message -> ( Message, Bool )
 preventDefaultOn commandMap spec editor msg =
     case msg of
         KeyDownEvent key ->
-            if key.isComposing then
+            if key.isComposing || isComposing editor then
                 ( msg, False )
 
             else
@@ -60,7 +60,7 @@ handleKeyDownEvent commandMap spec editor event =
 
 handleKeyDown : KeyboardEvent -> CommandMap -> Spec -> Editor -> Editor
 handleKeyDown keyboardEvent commandMap spec editor =
-    if keyboardEvent.isComposing then
+    if keyboardEvent.isComposing || isComposing editor then
         editor
 
     else


### PR DESCRIPTION
#10 This fixes IME support in chrome for desktop/mobile, and Safari.

Some more details on this implementation:
1) Reverts a performance improvement to return the modified editor on shouldPreventDefault for keydown and beforeinput.  Unfortunately, it sometimes can have a stale editor state, since the state gets passed in the view, not in the update method
2) Adds a custom `editorcompositionend` event which gets fired after the original to fix issues in some browsers where the final keydown and input event are fired after the composition event.
3) For android, makes sure that `compositionend` gets called eventually, since sometimes Android will never fire it.