### PR TITLE
#14: fix selection in composition by buffering during selection update

### DIFF
--- a/js/elmEditor.js
+++ b/js/elmEditor.js
@@ -238,7 +238,7 @@ class ElmEditor extends HTMLElement {
         // eventually.
         if (isAndroid()) {
             if (this.lastCompositionTimeout) {
-                clearTimeout(this.lastCompositionTimeout)
+                clearTimeout(this.lastCompositionTimeout);
             }
             const lastCompositionTimeout = setTimeout(() => {
                 if (this.composing && lastCompositionTimeout === this.lastCompositionTimeout) {

--- a/src/RichText/Editor.elm
+++ b/src/RichText/Editor.elm
@@ -207,7 +207,11 @@ updateSelection maybeSelection isDomPath spec_ editor_ =
                         Just selection
             in
             if isComposing editor_ then
-                editor_
+                let
+                    bufferedState =
+                        Maybe.withDefault editorState (bufferedEditorState editor_)
+                in
+                editor_ |> withBufferedEditorState (Just (bufferedState |> withSelection translatedSelection))
 
             else
                 editor_ |> withState (editorState |> withSelection translatedSelection)


### PR DESCRIPTION
See #14 

This PR buffers selection state during composition instead of throwing away that data.  It fixes an issue in chrome where some IME actions would have stale selection state.