### PR TITLE
Issue #16: ios safari cursor disappears

### DIFF
--- a/demo/src/css/rte.css
+++ b/demo/src/css/rte.css
@@ -17,8 +17,19 @@
     border: 1px solid #f2f2f2;
 }
 
+
 .rte-hide-caret {
     caret-color: transparent;
+}
+
+/*
+ * Workaround for https://github.com/mweiss/elm-rte-toolkit/issues/16, iOS has issues
+ * changing caret color on elements that are already selected.
+ */
+@supports (-webkit-touch-callout: none) {
+    .rte-hide-caret {
+        caret-color: auto;
+    }
 }
 
 .rte-button {

--- a/demo/src/css/rte.css
+++ b/demo/src/css/rte.css
@@ -17,7 +17,6 @@
     border: 1px solid #f2f2f2;
 }
 
-
 .rte-hide-caret {
     caret-color: transparent;
 }


### PR DESCRIPTION
See #16 

This is a workaround for a safari cursor issue.  We ignore the hide caret css for iOS.