### PR TITLE
fix to issue #4, use buffered state when doing comparison on composition

### DIFF
--- a/demo/tests/TestNode.elm
+++ b/demo/tests/TestNode.elm
@@ -793,10 +793,10 @@ testInsertBefore =
                 Expect.equal
                     (Err "I cannot insert a block node fragment into an inline leaf fragment")
                     (insertBefore [ 0, 0 ] blockInsertFragment rootNode)
-        , test "Trying to insert an inline fragment into an block array should result in an error" <|
+        , test "Trying to insert an inline fragment into a block array should result in an error" <|
             \_ ->
                 Expect.equal
-                    (Err "I cannot insert an inline leaf fragment fragment into an block node fragment")
+                    (Err "I cannot insert an inline leaf fragment fragment into a block node fragment")
                     (insertBefore [ 0 ] inlineInsertFragment rootNode)
         ]
 
@@ -845,10 +845,10 @@ testInsertAfter =
                 Expect.equal
                     (Err "I cannot insert a block node fragment into an inline leaf fragment")
                     (insertAfter [ 0, 0 ] blockInsertFragment rootNode)
-        , test "Trying to insert an inline fragment into an block array should result in an error" <|
+        , test "Trying to insert an inline fragment into a block array should result in an error" <|
             \_ ->
                 Expect.equal
-                    (Err "I cannot insert an inline leaf fragment fragment into an block node fragment")
+                    (Err "I cannot insert an inline leaf fragment fragment into a block node fragment")
                     (insertAfter [ 0 ] inlineInsertFragment rootNode)
         ]
 

--- a/src/RichText/Editor.elm
+++ b/src/RichText/Editor.elm
@@ -674,7 +674,7 @@ handleCompositionEnd editor_ =
             editor_ |> withComposing False
 
         Just _ ->
-            applyForceFunctionOnEditor forceReselection (editor_ |> withComposing False)
+            applyForceFunctionOnEditor forceReselection editor_
 
 
 shouldHideCaret : State -> Bool

--- a/src/RichText/Model/Mark.elm
+++ b/src/RichText/Model/Mark.elm
@@ -107,7 +107,7 @@ type alias Order =
                 ]
 
     sort (markOrderFromSpec spec) [mark italic [], mark bold []]
-    --> [mark bold [], mark bold []]
+    --> [mark bold [], mark italic []]
 
 -}
 sort : MarkOrder -> List Mark -> List Mark

--- a/src/RichText/Model/Node.elm
+++ b/src/RichText/Model/Node.elm
@@ -127,7 +127,7 @@ commonAncestor xPath yPath =
                         []
 
 
-{-| A `Block` represents a block element in your document. An block can either
+{-| A `Block` represents a block element in your document. A block can either
 have other block nodes as children, have all inline leaf nodes as children (e.g a text block),
 or be a leaf node.
 -}

--- a/src/RichText/Node.elm
+++ b/src/RichText/Node.elm
@@ -963,7 +963,7 @@ replaceWithFragment path fragment root =
                                 )
 
                         BlockFragment _ ->
-                            Err "I cannot replace an inline fragment with an block fragment"
+                            Err "I cannot replace an inline fragment with a block fragment"
 
                 Leaf ->
                     Err "Not implemented"
@@ -1715,7 +1715,7 @@ insertAfter path fragment root =
                             replaceWithFragment path newFragment root
 
                         InlineFragment _ ->
-                            Err "I cannot insert an inline leaf fragment fragment into an block node fragment"
+                            Err "I cannot insert an inline leaf fragment fragment into a block node fragment"
 
 
 {-| Inserts the fragments before the node at the given path and returns the result. Returns an
@@ -1755,7 +1755,7 @@ insertBefore path fragment root =
                             replaceWithFragment path newFragment root
 
                         InlineFragment _ ->
-                            Err "I cannot insert an inline leaf fragment fragment into an block node fragment"
+                            Err "I cannot insert an inline leaf fragment fragment into a block node fragment"
 
 
 {-| Runs the toggle action on the node for the given mark.


### PR DESCRIPTION
This PR does 2 things:
- Fix issue #4 by making sure we update the buffered state when the user deletes the changes made by composing.
- Updates some typos in the documentation and tests