### PR TITLE
Fix issue on demo page with dark reader

### DIFF
--- a/demo/src/Page.elm
+++ b/demo/src/Page.elm
@@ -37,7 +37,10 @@ view page { title, content } =
 
 fontAwesomeStyle : Html msg
 fontAwesomeStyle =
-    FontAwesome.Styles.css
+    -- Fix to Issue #20:
+    -- Wrap font awesome styles in a div because of dangerous extensions: https://discourse.elm-lang.org/t/runtime-errors-caused-by-chrome-extensions/
+    Html.div []
+        [ FontAwesome.Styles.css ]
 
 
 viewContent : List (Html msg) -> Html msg


### PR DESCRIPTION
See #20 and https://discourse.elm-lang.org/t/runtime-errors-caused-by-chrome-extensions/4381?u=mweiss

The demo page uses font-awesome, which inserts a style element in the beginning of the body.  However, dark reader, a chrome and firefox extension, will then insert its own style element after it for its own purposes and logic.  This confuses Elm's virtual dom, which just crashes and doesn't recover.  This is a workaround to wrap the styles in a div so even though its own of sync, because it never changes position in the app, it'll end up working.