### PR TITLE
fix to ordered list in markdown example

### DIFF
--- a/demo/src/Page/Markdown.elm
+++ b/demo/src/Page/Markdown.elm
@@ -573,7 +573,7 @@ listToMarkdown : M.ListType -> Element -> Children -> Result String MBlock
 listToMarkdown type_ parameters cn =
     let
         delimiter =
-            Maybe.withDefault "." <|
+            Maybe.withDefault "*" <|
                 findStringAttribute
                     "delimiter"
                     (Element.attributes parameters)


### PR DESCRIPTION
This fixes a typo in the ordered list markdown example