### PR TITLE
Fix removeInRange missing out elements in the range

### DIFF
--- a/src/RichText/Node.elm
+++ b/src/RichText/Node.elm
@@ -1260,7 +1260,7 @@ removeInRange start end node =
                                     Array.empty
 
                                 Just b ->
-                                    Array.fromList [ removeInRange startRest endRest b ]
+                                    Array.fromList [ removeInRange startRest (last b |> Tuple.first) b ]
 
                     rightRest =
                         if List.isEmpty endRest then
@@ -1272,7 +1272,7 @@ removeInRange start end node =
                                     Array.empty
 
                                 Just b ->
-                                    Array.fromList [ removeInRange startRest endRest b ]
+                                    Array.fromList [ removeInRange [] endRest b ]
                 in
                 node |> withChildNodes (blockChildren <| List.foldr Array.append Array.empty [ left, leftRest, rightRest, right ])
 


### PR DESCRIPTION
## Issue

Copy the below ABCD paragraph + list and paste it into https://mweiss.github.io/elm-rte-toolkit/#/examples/basic.

<p>A</p><ol><li><p>B</p></li><li><p>C</p></li><li><p>D</p></li></ol>

Then select all (Ctrl + A) and then Backspace. The B item is left behind:
<img src="https://user-images.githubusercontent.com/6631310/102349805-d28f0080-3f9b-11eb-8107-fc03f2abcf0e.png" width="500">

## Fix

The `removeInRange` function appears to be wrong. In the case that `startIndex /= endIndex`, `leftRest` and `rightRest` are recursively edited between `startRest` and `endRest`, while `leftRest` should be edited between `startRest` and the end of that node, and `rightRest` should be edited between the start of that node and `endRest`.