### PR TITLE
Small documentation fix 

### DIFF
--- a/src/RichText/Html.elm
+++ b/src/RichText/Html.elm
@@ -1,6 +1,6 @@
 module RichText.Html exposing (toHtml, toHtmlNode, fromHtml, blockFromHtml)
 
-{-| This module contains convenience functions for econding and decoding editor nodes to and from
+{-| This module contains convenience functions for encoding and decoding editor nodes to and from
 html. Its intent is to help developers who want to import and export editor state
 as html.
 

--- a/src/RichText/Model/Node.elm
+++ b/src/RichText/Model/Node.elm
@@ -7,7 +7,7 @@ module RichText.Model.Node exposing
 
 {-| This module contains types related to the nodes in an editor.
 
-An editor consists of two types of nodes, block and inline. Block nodes are used to represent
+An editor consists of two types of nodes, block and inline. `Block` nodes are used to represent
 hierarchical structures like blockquotes, tables and nested lists. Inline nodes are used to
 represent flat structures, like text, inline images, and hard breaks.
 

--- a/src/RichText/Model/Selection.elm
+++ b/src/RichText/Model/Selection.elm
@@ -4,8 +4,8 @@ module RichText.Model.Selection exposing
     , isCollapsed, normalize
     )
 
-{-| A selection represents the information received and translated from the selection web API. Note that
-the anchorNode and focusNode are translations of the node paths relative to the editor.
+{-| A `Selection` represents the information received and translated from the selection web API. Note that
+the `anchorNode` and `focusNode` are translations of the node paths relative to the editor.
 
 
 # Selection
@@ -28,7 +28,7 @@ import RichText.Model.Node exposing (Path)
 
 
 {-| A `Selection` represents the information received and translated from the selection API. Note that
-the anchorNode and focusNode are translations of the node paths relative to the editor.
+the `anchorNode` and `focusNode` are translations of the node paths relative to the editor.
 -}
 type Selection
     = Selection Contents

--- a/src/RichText/Model/State.elm
+++ b/src/RichText/Model/State.elm
@@ -1,6 +1,6 @@
 module RichText.Model.State exposing (State, state, root, selection, withRoot, withSelection)
 
-{-| A State consists of a root block and a selection. State allows you to keep
+{-| A `State` consists of a root block and a selection. `State` allows you to keep
 track of and manipulate the contents of the editor.
 
 @docs State, state, root, selection, withRoot, withSelection
@@ -11,7 +11,7 @@ import RichText.Model.Node exposing (Block)
 import RichText.Model.Selection exposing (Selection)
 
 
-{-| A State consists of a root block and a selection. State allows you to keep
+{-| A `State` consists of a root block and a selection. `State` allows you to keep
 track of and manipulate the contents of the editor.
 -}
 type State

--- a/src/RichText/Node.elm
+++ b/src/RichText/Node.elm
@@ -10,7 +10,7 @@ module RichText.Node exposing
     , Fragment(..), Node(..)
     )
 
-{-| This module contains convenience functions for working with Block and Inline nodes.
+{-| This module contains convenience functions for working with `Block` and `Inline` nodes.
 
 
 # Insert / Replace


### PR DESCRIPTION
Correct typo; Add fixed-width `code` styling to docs to denote types.

Thank you for @mweiss. I noticed the small typo, and didn't need to make the style changes (but felt silly only submitting a two character change).