### PR TITLE
click to select

### DIFF
--- a/src/RichText/Config/Decorations.elm
+++ b/src/RichText/Config/Decorations.elm
@@ -29,7 +29,6 @@ import RichText.Internal.Editor exposing (Message(..), Tagger)
 import RichText.Model.Element exposing (Element, annotations)
 import RichText.Model.Mark exposing (Mark)
 import RichText.Model.Node exposing (Path)
-import RichText.Model.Selection exposing (caret)
 import Set
 
 
@@ -229,6 +228,6 @@ selectableDecoration tagger editorNodePath elementParameters _ =
     )
         ++ [ Html.Events.onClick
                 (tagger <|
-                    SelectionEvent (Just (caret editorNodePath 0)) False
+                    SelectElement editorNodePath
                 )
            ]

--- a/src/RichText/Internal/Editor.elm
+++ b/src/RichText/Internal/Editor.elm
@@ -10,6 +10,7 @@ import RichText.Config.Keys exposing (meta)
 import RichText.Config.Spec exposing (Spec)
 import RichText.Internal.Event exposing (EditorChange, InitEvent, InputEvent, KeyboardEvent, PasteEvent)
 import RichText.Internal.History exposing (History, contents, empty, fromContents)
+import RichText.Model.Node exposing (Path)
 import RichText.Model.Selection exposing (Selection)
 import RichText.Model.State exposing (State)
 import RichText.State exposing (reduce, validate)
@@ -62,7 +63,8 @@ editor iState =
 {-| The internal events that an editor has to respond to. These events should be mapped via a Tagger.
 -}
 type Message
-    = SelectionEvent (Maybe Selection) Bool
+    = SelectionEvent (Maybe Selection)
+    | SelectElement Path
     | ChangeEvent EditorChange
     | BeforeInputEvent InputEvent
     | KeyDownEvent KeyboardEvent


### PR DESCRIPTION
`Config.Decorations.selectableDecoration` should select element using DOM's `setBaseAndExtent`.

That ensures that browser selection is the same as editor selection.

That removes needs for `.rte-hide-caret { caret-color: transparent; }`.

Also also solves #16.

And also allows use "click and copy and paste".
