### PR TITLE
Do not return early if other mutation types are observed

### DIFF
--- a/js/elmEditor.js
+++ b/js/elmEditor.js
@@ -321,17 +321,7 @@ class ElmEditor extends HTMLElement {
             return null;
         }
 
-        let mutations = [];
-        for (let mutation of mutationsList) {
-            if (mutation.type !== "characterData") {
-                return null;
-            }
-            mutations.push({
-                path: getSelectionPath(mutation.target, this, 0),
-                text: mutation.target.nodeValue
-            });
-        }
-        return mutations;
+        return mutationsList.filter(mutation => mutation.type !== "characterData";
     }
 
     mutationObserverCallback(mutationsList, _) {

--- a/js/elmEditor.js
+++ b/js/elmEditor.js
@@ -321,7 +321,7 @@ class ElmEditor extends HTMLElement {
             return null;
         }
 
-        return mutationsList.filter(mutation => mutation.type !== "characterData";
+        return mutationsList.filter(mutation => mutation.type === "characterData");
     }
 
     mutationObserverCallback(mutationsList, _) {


### PR DESCRIPTION
"childList" will appear in Firefox when adding spaces to the end of a line. The mutationRecords returned look like this:
```js
[
{type: "characterData", ...}, // Original state
{type: "childList", ...}, // Something we don't care about
{type: "characterData", ...} // This one contains the changes
]
```

Since we exit early we only see the original state and the space we were trying to add is not seen. This replaces that behavior by just filtering out any non `characterData` mutation records.